### PR TITLE
corrected wrong endpoints for function checkRecipient

### DIFF
--- a/class-gf-mailup.php
+++ b/class-gf-mailup.php
@@ -909,7 +909,7 @@ class GFMailUp extends GFFeedAddOn
         $recipientStatus = '';
 
         //check subscribed
-        $url = $mailUp->getConsoleEndpoint() . "/Console/List/$list_id/Recipients/subscribed?filterby=\"Email.Contains('$email')\"";
+        $url = $mailUp->getConsoleEndpoint() . "/Console/List/$list_id/Recipients/Subscribed?filterby=\"Email.Contains('$email')\"";
         $recipientExists = $mailUp->callMethod($url, "GET", null, "JSON");
         $recipientExists = json_decode($recipientExists);
 
@@ -919,7 +919,7 @@ class GFMailUp extends GFFeedAddOn
 
         if ($recipientFound == 0) {
             //check pending
-            $url = $mailUp->getConsoleEndpoint() . "/Console/List/$list_id/Recipients/pending?filterby=\"Email.Contains('$email')\"";
+            $url = $mailUp->getConsoleEndpoint() . "/Console/List/$list_id/Recipients/Pending?filterby=\"Email.Contains('$email')\"";
             $recipientExists = $mailUp->callMethod($url, "GET", null, "JSON");
             $recipientExists = json_decode($recipientExists);
             $recipientFound = $recipientExists->TotalElementsCount;
@@ -928,7 +928,7 @@ class GFMailUp extends GFFeedAddOn
 
         if ($recipientFound == 0) {
             //check unsubscribed
-            $url = $mailUp->getConsoleEndpoint() . "/Console/List/$list_id/Recipients/unsubscribed?filterby=\"Email.Contains('$email')\"";
+            $url = $mailUp->getConsoleEndpoint() . "/Console/List/$list_id/Recipients/Unsubscribed?filterby=\"Email.Contains('$email')\"";
             $recipientExists = $mailUp->callMethod($url, "GET", null, "JSON");
             $recipientExists = json_decode($recipientExists);
             $recipientFound = $recipientExists->TotalElementsCount;


### PR DESCRIPTION
After 7 hours of reverse engineering the code, i realized that you're not respecting corrected endpoint format (mannaggi'a'té). 
Anyway lowercase endpoints worked until last wednesday, though i dunno why...
Please refer to the Mailup API doc here: http://help.mailup.com/display/mailupapi/Recipients